### PR TITLE
Add RKE Support Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,112 @@
-Cisco ACI and Rancher Integration Guides
-------------------------
-* [Cisco ACI and Rancher Integration with RKE 1.4.9](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-149.html)
-* [Cisco ACI and Rancher Integration with RKE 1.3.24](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-1324.html)
-* [Cisco ACI and Rancher Integration with RKE 1.3.13](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-1313.html)
+<table>
+  <thead>
+    <tr>
+      <th>ACI-CNI version</th>
+      <th>RKE (flavor) version</th>
+      <th>Rancher version</th>
+      <th>Kubernetes versions</th>
+      <th>Parameters</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="5">5.2.7.1</td>
+      <td rowspan="3">1.4.6</td>
+      <td rowspan="3">2.7.6 (RKE  v1.4.8)</td>
+      <td>1.26.4-rancher2-1</td>
+      <td rowspan="5">
+        <pre>kube_config:
+  opflex_agent_policy_retry_delay_timer
+  aci_multipod
+  aci_multipod_ubuntu
+  dhcp_renew_max_retry_count
+  dhcp_delay
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>1.25.9-rancher2-2</td>
+    </tr>
+    <tr>
+      <td>1.24.13-rancher2-2</td>
+    </tr>
+    <tr>
+      <td rowspan="2">1.3.21</td>
+      <td rowspan="2">2.6.14 (RKE v1.3.24)</td>
+      <td>1.24.13-rancher2-2</td>
+    </tr>
+    <tr>
+      <td>1.23.16-rancher2-3</td>
+    </tr>
+    <tr>
+      <td rowspan="4">6.0.3.1</td>
+      <td rowspan="3">1.4.9</td>
+      <td rowspan="3">2.7.9 (RKE  v1.4.10)</td>
+      <td>1.26.8-rancher1-1</td>
+      <td rowspan="4">
+        <pre>kube_config:
+  use_system_node_priority_class
+  ovs_memory_request
+  aci_containers_controller_memory_limit
+  aci_containers_controller_memory_request
+  aci_containers_host_memory_limit
+  aci_containers_host_memory_request
+  mcast_daemon_memory_limit
+  mcast_daemon_memory_request
+  opflex_agent_memory_limit
+  opflex_agent_memory_request
+  aci_containers_memory_limit
+  aci_containers_memory_request
+  opflex_device_reconnect_wait_timeout
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>1.25.13-rancher1-1</td>
+    </tr>
+    <tr>
+      <td>1.24.17-rancher1-1</td>
+    </tr>
+    <tr>
+      <td>1.3.24</td>
+      <td>2.6.14 (RKE v1.3.24)</td>
+      <td>1.24.17-rancher1-1</td>
+    </tr>
+    <tr>
+      <td rowspan="6">6.0.3.2</td>
+      <td rowspan="3">1.5.3</td>
+      <td rowspan="3">2.8.2 (RKE v1.5.3)</td>
+      <td>1.27.8-rancher2-2</td>
+      <td rowspan="6">
+        <pre>kube_config:
+  opflex_agent_statistics
+  add_external_contract_to_default_epg
+  enable_opflex_agent_reconnect
+  opflex_openssl_compat
+  node_snat_redirect_exclude
+  toleration_seconds
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>1.26.11-rancher2-2</td>
+    </tr>
+    <tr>
+      <td>1.25.16-rancher2-2</td>
+    </tr>
+    <tr>
+      <td rowspan="3">1.4.13</td>
+      <td rowspan="3">2.7.10 (RKE v1.4.13)</td>
+      <td>1.26.11-rancher2-2</td>
+    </tr>
+    <tr>
+      <td>1.25.16-rancher2-2</td>
+    </tr>
+</tbody>
+</table>
+
+## Cisco ACI and Rancher Integration Guides
+
+- [Cisco ACI and Rancher Integration with RKE 1.4.9](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-149.html)
+- [Cisco ACI and Rancher Integration with RKE 1.3.24](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-1324.html)
+- [Cisco ACI and Rancher Integration with RKE 1.3.13](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-1313.html)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
   <thead>
     <tr>
       <th>ACI-CNI version</th>
-      <th>RKE (flavor) version</th>
+      <th>RKE version</th>
+      <th>acc-provision flavor</th>
       <th>Rancher version</th>
       <th>Kubernetes versions</th>
       <th>Parameters</th>
@@ -12,6 +13,7 @@
     <tr>
       <td rowspan="5">5.2.7.1</td>
       <td rowspan="3">1.4.6</td>
+      <td rowspan="3">RKE-1.4.6</td>
       <td rowspan="3">2.7.6 (RKE  v1.4.8)</td>
       <td>1.26.4-rancher2-1</td>
       <td rowspan="5">
@@ -32,6 +34,7 @@
     </tr>
     <tr>
       <td rowspan="2">1.3.21</td>
+      <td rowspan="2">RKE-1.3.21</td>
       <td rowspan="2">2.6.14 (RKE v1.3.24)</td>
       <td>1.24.13-rancher2-2</td>
     </tr>
@@ -41,6 +44,7 @@
     <tr>
       <td rowspan="4">6.0.3.1</td>
       <td rowspan="3">1.4.9</td>
+      <td rowspan="3">RKE-1.4.9</td>
       <td rowspan="3">2.7.9 (RKE  v1.4.10)</td>
       <td>1.26.8-rancher1-1</td>
       <td rowspan="4">
@@ -69,12 +73,14 @@
     </tr>
     <tr>
       <td>1.3.24</td>
+      <td>RKE-1.3.24</td>
       <td>2.6.14 (RKE v1.3.24)</td>
       <td>1.24.17-rancher1-1</td>
     </tr>
     <tr>
       <td rowspan="6">6.0.3.2</td>
       <td rowspan="3">1.5.3</td>
+      <td rowspan="3">RKE-1.5.3</td>
       <td rowspan="3">2.8.2 (RKE v1.5.3)</td>
       <td>1.27.8-rancher2-2</td>
       <td rowspan="6">
@@ -96,6 +102,7 @@
     </tr>
     <tr>
       <td rowspan="3">1.4.13</td>
+      <td rowspan="3">RKE-1.4.13</td>
       <td rowspan="3">2.7.10 (RKE v1.4.13)</td>
       <td>1.26.11-rancher2-2</td>
     </tr>
@@ -107,6 +114,8 @@
 
 ## Cisco ACI and Rancher Integration Guides
 
+- [Cisco ACI and Rancher Integration with RKE 1.5.3]()
+- [Cisco ACI and Rancher Integration with RKE 1.4.13]()
 - [Cisco ACI and Rancher Integration with RKE 1.4.9](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-149.html)
 - [Cisco ACI and Rancher Integration with RKE 1.3.24](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-1324.html)
 - [Cisco ACI and Rancher Integration with RKE 1.3.13](https://www.cisco.com/c/en/us/td/docs/dcn/aci/containers/rancher-and-cisco-aci-integration/cisco-aci-and-rancher-integration-with-rke-1313.html)


### PR DESCRIPTION
Add table with details of ACI-CNI support in RKE1.
- The RKE version (the acc-provision flavor)
- The Rancher version from which the support is available
- The Kubernetes versions to which the ACI-CNI version is mapped
- The configuration parameters supported