### PR TITLE
Add RKE2 pre-requisites Info

### DIFF
--- a/docs/rke2-6042.md
+++ b/docs/rke2-6042.md
@@ -1,6 +1,7 @@
 # Installing RKE2 cluster with ACI-CNI 6.0.4.2 from Rancher UI
 
 # Table of contents
+- [Installing RKE2 cluster with ACI-CNI 6.0.4.2 from Rancher UI](#installing-rke2-cluster-with-aci-cni-6042-from-rancher-ui)
 - [Table of contents](#table-of-contents)
   - [Cluster Installation](#cluster-installation)
     - [Pre-requisites](#pre-requisites)
@@ -15,22 +16,42 @@
 ## Cluster Installation 
 
 ### Pre-requisites
+ Complete the following tasks before proceeding with installation, following the referenced procedures on the Rancher and Cisco websites. 
+1.  Configure the following:
+    -   A Cisco Application Centric Infrastructure (ACI) tenant
+    -   An attachable entity profile (AEP)
+    -   A VRF
+    -   A Layer 3 outside connection (L3Out)
+    -   A Layer 3 external network for the cluster you plan to provision 
 
-0. \[Optional\] If you are installing the Logging and Monitoring apps on top of your RKE2 cluster and you want to override the "cattle-logging" and "cattle-prometheus" default namespaces. Set the variables 'logging_namespace' and 'monitoring_namespace' under 'rke2_config' to specify the name of the namespace in which the apps are desired to be installed.
+    > Note: The VRF and L3Out in Cisco ACI that you use to provide outside connectivity to Kubernetes external services can be in any tenant. The VRF and L3Out are usually in the common tenant or in a tenant that you dedicate to the Kubernetes cluster. You can also have separate VRFs, one for the Kubernetes bridge domains and one for the L3Out, and you can configure route leaking between them.  
 
-    ![](images/rke2-6041/1.jpg)
+2. Prepare the nodes for Cisco ACI Container Network Interface (CNI) plug-in installation.
+
+    Follow the procedures in *[Cisco ACI and Kubernetes Integration](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/kb/b_Kubernetes_Integration_with_ACI.html#concept_ew3_bnz_n1b)* on cisco.com until the end of the section, *Preparing the Kubernetes Nodes*.
     
-1. Install latest acc-provision 
+    > Note: ACI CNI in nested mode is only supported with VMM-integrated VMware (with Distributed Virtual Switch).
+
+3. Have a working [Rancher server installation](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade), reachable from your user cluster nodes.
+
+4.  Fulfill the requirements for the nodes where you will install apps and services, including networking requirements for RKE2. See the page Node Requirements on the Rancher and RKE2 websites.
+
+5. Install latest acc-provision 
     ```sh
     sudo pip3 install acc-provision==6.0.4.2
     ```
-2. Generate aci-cni manifests using acc-provision tool with the appropriate RKE2 flavor.
-    Note: the `-a` option will push the config to your ACI Fabric and create the required resources.
+
+6. Generate aci-cni manifests using acc-provision tool with the appropriate RKE2 flavor.
+    
     ![](images/rke2-6041/2.png)
 
     ```sh
     acc-provision -c acc_provision_input.yaml -u <username> -p <password> -a -f RKE2-kubernetes-1.27 -o rke2-manifests.yaml
     ```
+
+    > Note: the `-a` option will push the config to your ACI Fabric and create the required resources.
+
+    > *Optional*: If you are installing the Logging and Monitoring apps on top of your RKE2 cluster and you want to override the "cattle-logging" and "cattle-prometheus" default namespaces. Set the variables 'logging_namespace' and 'monitoring_namespace' under 'rke2_config' to specify the name of the namespace in which the apps are desired to be installed.
 
 ### Installation 
 


### PR DESCRIPTION
Add information regarding ACI and Node configuration pre-requisites for RKE2 installation.

Addresses: https://github.com/noironetworks/rancher-docs/issues/14